### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -16,7 +16,7 @@ icon-path = "meta.png"
 language = "Rust"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release && cp ./target/wasm32-wasip2/release/meta_capi_component.wasm meta_capi.wasm"
+command = "cargo build --target wasm32-wasip2 --release && rm -f meta_capi.wasm && cp ./target/wasm32-wasip2/release/meta_capi_component.wasm meta_capi.wasm"
 output_path = "meta_capi.wasm"
 
 [component.settings.meta_pixel_id]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn build_edgee_request(meta_payload: MetaPayload) -> EdgeeRequest {
     );
 
     let url = if let Some(test_code) = meta_payload.test_event_code.clone() {
-        format!("{}&test_event_code={}", url, test_code)
+        format!("{url}&test_event_code={test_code}")
     } else {
         url
     };


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink